### PR TITLE
Add examples of language extension sets

### DIFF
--- a/dhall/GHC/LanguageEdition/compatibleWith
+++ b/dhall/GHC/LanguageEdition/compatibleWith
@@ -16,7 +16,10 @@ let GHC2021 = ./GHC2021
 
 let GHC2024 = ./GHC2024
 
-let versionExtensions =
+let -- Adds `extensions` to either `additionalExtensions` or
+    -- `unsupportedExtensions` depending on whether `minimumGhcVersion` supports
+    -- them.
+    versionExtensions =
       λ(ghcVersion : Pvp.Version) →
       λ(minimumGhcVersion : Pvp.Version) →
       λ(extensions : List Text) →
@@ -36,72 +39,72 @@ let versionExtensions =
 let ghc2021CompatibleWith
     : Pvp.Version → CompositeEdition
     = λ(minimumGhcVersion : Pvp.Version) →
-        versionExtensions
-          ghc.v8-10-1.version
-          minimumGhcVersion
-          [ "DeriveLift", "ImportQualifiedPost", "StandaloneKindSignatures" ]
-          ( versionExtensions
-              ghc.v8-6-1.version
-              minimumGhcVersion
-              [ "NumericUnderscores" ]
-              ( versionExtensions
-                  ghc.v8-4-1.version
-                  minimumGhcVersion
-                  [ "HexFloatLiterals" ]
-                  ( versionExtensions
-                      ghc.v8-0-1.version
-                      minimumGhcVersion
-                      [ "TypeApplications" ]
-                      (   ( if    Pvp.lessThanEqual
-                                    ghc.v9-2-1.version
-                                    minimumGhcVersion
-                            then  { baseEdition = GHC2021
-                                  , additionalExtensions = [] : List Text
-                                  , unsupportedExtensions = [] : List Text
-                                  }
-                            else  { baseEdition = Haskell2010
-                                  , additionalExtensions =
-                                    [ "BangPatterns"
-                                    , "BinaryLiterals"
-                                    , "ConstrainedClassMethods"
-                                    , "ConstraintKinds"
-                                    , "DeriveDataTypeable"
-                                    , "DeriveFoldable"
-                                    , "DeriveFunctor"
-                                    , "DeriveGeneric"
-                                    , "DeriveTraversable"
-                                    , "DerivingStrategies"
-                                    , "EmptyCase"
-                                    , "EmptyDataDeriving"
-                                    , "ExistentialQuantification"
-                                    , "ExplicitForAll"
-                                    , "FlexibleContexts"
-                                    , "FlexibleInstances"
-                                    , "GADTSyntax"
-                                    , "GeneralizedNewtypeDeriving"
-                                    , "InstanceSigs"
-                                    , "KindSignatures"
-                                    , "MultiParamTypeClasses"
-                                    , "NamedFieldPuns"
-                                    , "NamedWildCards"
-                                    , "PolyKinds"
-                                    , "PostfixOperators"
-                                    , "RankNTypes"
-                                    , "ScopedTypeVariables"
-                                    , "StandaloneDeriving"
-                                    , "TupleSections"
-                                    , "TypeOperators"
-                                    , "TypeSynonymInstances"
-                                    , "NoExplicitNamespaces"
-                                    ]
-                                  , unsupportedExtensions = [] : List Text
-                                  }
-                          )
-                        ⫽ { name = GHC2021.name }
-                      )
-                  )
-              )
-          )
+        if    Pvp.lessThanEqual ghc.v9-2-1.version minimumGhcVersion
+        then  { name = GHC2021.name
+              , baseEdition = GHC2021
+              , additionalExtensions = [] : List Text
+              , unsupportedExtensions = [] : List Text
+              }
+        else  versionExtensions
+                ghc.v8-10-1.version
+                minimumGhcVersion
+                [ "DeriveLift"
+                , "ImportQualifiedPost"
+                , "StandaloneKindSignatures"
+                ]
+                ( versionExtensions
+                    ghc.v8-6-1.version
+                    minimumGhcVersion
+                    [ "NumericUnderscores" ]
+                    ( versionExtensions
+                        ghc.v8-4-1.version
+                        minimumGhcVersion
+                        [ "HexFloatLiterals" ]
+                        ( versionExtensions
+                            ghc.v8-0-1.version
+                            minimumGhcVersion
+                            [ "TypeApplications" ]
+                            { name = GHC2021.name
+                            , baseEdition = Haskell2010
+                            , additionalExtensions =
+                              [ "BangPatterns"
+                              , "BinaryLiterals"
+                              , "ConstrainedClassMethods"
+                              , "ConstraintKinds"
+                              , "DeriveDataTypeable"
+                              , "DeriveFoldable"
+                              , "DeriveFunctor"
+                              , "DeriveGeneric"
+                              , "DeriveTraversable"
+                              , "DerivingStrategies"
+                              , "EmptyCase"
+                              , "EmptyDataDeriving"
+                              , "ExistentialQuantification"
+                              , "ExplicitForAll"
+                              , "FlexibleContexts"
+                              , "FlexibleInstances"
+                              , "GADTSyntax"
+                              , "GeneralizedNewtypeDeriving"
+                              , "InstanceSigs"
+                              , "KindSignatures"
+                              , "MultiParamTypeClasses"
+                              , "NamedFieldPuns"
+                              , "NamedWildCards"
+                              , "PolyKinds"
+                              , "PostfixOperators"
+                              , "RankNTypes"
+                              , "ScopedTypeVariables"
+                              , "StandaloneDeriving"
+                              , "TupleSections"
+                              , "TypeOperators"
+                              , "TypeSynonymInstances"
+                              , "NoExplicitNamespaces"
+                              ]
+                            , unsupportedExtensions = [] : List Text
+                            }
+                        )
+                    )
+                )
 
 let ghc2024CompatibleWith
     : Pvp.Version → CompositeEdition

--- a/dhall/GHC/package.dhall
+++ b/dhall/GHC/package.dhall
@@ -1,3 +1,262 @@
-{ LanguageEdition = ./LanguageEdition/package.dhall
-, Release = ./Release/package.dhall
-}
+{-| Information about GHC releases, etc.
+
+One common use case for this is creating flexible sets of language extensions
+depending on the versions of GHC you support. See the examples below.
+-}
+let p =
+      { LanguageEdition = ./LanguageEdition/package.dhall
+      , Release = ./Release/package.dhall
+      }
+
+let edition = p.LanguageEdition
+
+let ghc = p.Release
+
+let -- Removes all the extra information from `edition.compatibleWith` to
+    -- produce something that can be used in a Cabal stanza.
+    compat =
+      λ(ed : edition.Type) →
+      λ(minimumGhcVersion : ghc.Type) →
+        let generated = edition.compatibleWith ed minimumGhcVersion.version
+
+        in  { language = generated.baseEdition.name
+            , defaultExtensions = generated.additionalExtensions
+            }
+
+let Haskell2010-for-GHC-9-10 =
+        assert
+      :   compat edition.Haskell2010 ghc.v9-10-1
+        ≡ { language = "Haskell2010", defaultExtensions = [] : List Text }
+
+let GHC2021-for-GHC-9-10 =
+        assert
+      :   compat edition.GHC2021 ghc.v9-10-1
+        ≡ { language = "GHC2021", defaultExtensions = [] : List Text }
+
+let GHC2024-for-GHC-9-10 =
+        assert
+      :   compat edition.GHC2024 ghc.v9-10-1
+        ≡ { language = "GHC2024", defaultExtensions = [] : List Text }
+
+let Haskell2010-for-GHC-9-2 =
+        assert
+      :   compat edition.Haskell2010 ghc.v9-2-1
+        ≡ { language = "Haskell2010", defaultExtensions = [] : List Text }
+
+let GHC2021-for-GHC-9-2 =
+        assert
+      :   compat edition.GHC2021 ghc.v9-2-1
+        ≡ { language = "GHC2021", defaultExtensions = [] : List Text }
+
+let GHC2024-for-GHC-9-2 =
+        assert
+      :   compat edition.GHC2024 ghc.v9-2-1
+        ≡ { language = "GHC2021"
+          , defaultExtensions =
+            [ "DataKinds"
+            , "DerivingStrategies"
+            , "DisambiguateRecordFields"
+            , "ExplicitNamespaces"
+            , "GADTs"
+            , "LambdaCase"
+            , "MonoLocalBinds"
+            , "RoleAnnotations"
+            ]
+          }
+
+let Haskell2010-for-GHC-8-6 =
+        assert
+      :   compat edition.Haskell2010 ghc.v8-6-1
+        ≡ { language = "Haskell2010", defaultExtensions = [] : List Text }
+
+let GHC2021-for-GHC-8-6 =
+        assert
+      :   compat edition.GHC2021 ghc.v8-6-1
+        ≡ { language = "Haskell2010"
+          , defaultExtensions =
+            [ "BangPatterns"
+            , "BinaryLiterals"
+            , "ConstrainedClassMethods"
+            , "ConstraintKinds"
+            , "DeriveDataTypeable"
+            , "DeriveFoldable"
+            , "DeriveFunctor"
+            , "DeriveGeneric"
+            , "DeriveTraversable"
+            , "DerivingStrategies"
+            , "EmptyCase"
+            , "EmptyDataDeriving"
+            , "ExistentialQuantification"
+            , "ExplicitForAll"
+            , "FlexibleContexts"
+            , "FlexibleInstances"
+            , "GADTSyntax"
+            , "GeneralizedNewtypeDeriving"
+            , "InstanceSigs"
+            , "KindSignatures"
+            , "MultiParamTypeClasses"
+            , "NamedFieldPuns"
+            , "NamedWildCards"
+            , "PolyKinds"
+            , "PostfixOperators"
+            , "RankNTypes"
+            , "ScopedTypeVariables"
+            , "StandaloneDeriving"
+            , "TupleSections"
+            , "TypeOperators"
+            , "TypeSynonymInstances"
+            , "NoExplicitNamespaces"
+            , "TypeApplications"
+            , "HexFloatLiterals"
+            , "NumericUnderscores"
+            ]
+          }
+
+let GHC2024-for-GHC-8-6 =
+        assert
+      :   compat edition.GHC2024 ghc.v8-6-1
+        ≡ { language = "Haskell2010"
+          , defaultExtensions =
+            [ "BangPatterns"
+            , "BinaryLiterals"
+            , "ConstrainedClassMethods"
+            , "ConstraintKinds"
+            , "DeriveDataTypeable"
+            , "DeriveFoldable"
+            , "DeriveFunctor"
+            , "DeriveGeneric"
+            , "DeriveTraversable"
+            , "DerivingStrategies"
+            , "EmptyCase"
+            , "EmptyDataDeriving"
+            , "ExistentialQuantification"
+            , "ExplicitForAll"
+            , "FlexibleContexts"
+            , "FlexibleInstances"
+            , "GADTSyntax"
+            , "GeneralizedNewtypeDeriving"
+            , "InstanceSigs"
+            , "KindSignatures"
+            , "MultiParamTypeClasses"
+            , "NamedFieldPuns"
+            , "NamedWildCards"
+            , "PolyKinds"
+            , "PostfixOperators"
+            , "RankNTypes"
+            , "ScopedTypeVariables"
+            , "StandaloneDeriving"
+            , "TupleSections"
+            , "TypeOperators"
+            , "TypeSynonymInstances"
+            , "NoExplicitNamespaces"
+            , "TypeApplications"
+            , "HexFloatLiterals"
+            , "NumericUnderscores"
+            , "DataKinds"
+            , "DerivingStrategies"
+            , "DisambiguateRecordFields"
+            , "ExplicitNamespaces"
+            , "GADTs"
+            , "LambdaCase"
+            , "MonoLocalBinds"
+            , "RoleAnnotations"
+            ]
+          }
+
+let Haskell2010-for-GHC-7-10 =
+        assert
+      :   compat edition.Haskell2010 ghc.v7-10-3
+        ≡ { language = "Haskell2010", defaultExtensions = [] : List Text }
+
+let GHC2021-for-GHC-7-10 =
+        assert
+      :   compat edition.GHC2021 ghc.v7-10-3
+        ≡ { language = "Haskell2010"
+          , defaultExtensions =
+            [ "BangPatterns"
+            , "BinaryLiterals"
+            , "ConstrainedClassMethods"
+            , "ConstraintKinds"
+            , "DeriveDataTypeable"
+            , "DeriveFoldable"
+            , "DeriveFunctor"
+            , "DeriveGeneric"
+            , "DeriveTraversable"
+            , "DerivingStrategies"
+            , "EmptyCase"
+            , "EmptyDataDeriving"
+            , "ExistentialQuantification"
+            , "ExplicitForAll"
+            , "FlexibleContexts"
+            , "FlexibleInstances"
+            , "GADTSyntax"
+            , "GeneralizedNewtypeDeriving"
+            , "InstanceSigs"
+            , "KindSignatures"
+            , "MultiParamTypeClasses"
+            , "NamedFieldPuns"
+            , "NamedWildCards"
+            , "PolyKinds"
+            , "PostfixOperators"
+            , "RankNTypes"
+            , "ScopedTypeVariables"
+            , "StandaloneDeriving"
+            , "TupleSections"
+            , "TypeOperators"
+            , "TypeSynonymInstances"
+            , "NoExplicitNamespaces"
+            ]
+          }
+
+let -- NB: Relative to `GHC2024-for-GHC-8-6`, this is missing a few extensions.
+    --     That’s because they didn’t exist in GHC 7.10, so we can only
+    --    _approximate_ the GHC2024 edition.
+    GHC2024-for-GHC-7-10 =
+        assert
+      :   compat edition.GHC2024 ghc.v7-10-3
+        ≡ { language = "Haskell2010"
+          , defaultExtensions =
+            [ "BangPatterns"
+            , "BinaryLiterals"
+            , "ConstrainedClassMethods"
+            , "ConstraintKinds"
+            , "DeriveDataTypeable"
+            , "DeriveFoldable"
+            , "DeriveFunctor"
+            , "DeriveGeneric"
+            , "DeriveTraversable"
+            , "DerivingStrategies"
+            , "EmptyCase"
+            , "EmptyDataDeriving"
+            , "ExistentialQuantification"
+            , "ExplicitForAll"
+            , "FlexibleContexts"
+            , "FlexibleInstances"
+            , "GADTSyntax"
+            , "GeneralizedNewtypeDeriving"
+            , "InstanceSigs"
+            , "KindSignatures"
+            , "MultiParamTypeClasses"
+            , "NamedFieldPuns"
+            , "NamedWildCards"
+            , "PolyKinds"
+            , "PostfixOperators"
+            , "RankNTypes"
+            , "ScopedTypeVariables"
+            , "StandaloneDeriving"
+            , "TupleSections"
+            , "TypeOperators"
+            , "TypeSynonymInstances"
+            , "NoExplicitNamespaces"
+            , "DataKinds"
+            , "DerivingStrategies"
+            , "DisambiguateRecordFields"
+            , "ExplicitNamespaces"
+            , "GADTs"
+            , "LambdaCase"
+            , "MonoLocalBinds"
+            , "RoleAnnotations"
+            ]
+          }
+
+in  p


### PR DESCRIPTION
This also fixes a bug in `compatibleWith`, where we would include redundant extensions in some cases.